### PR TITLE
package.json, license, linter fixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2015 Tim Wisniewski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Using `https://services.arcgis.com/fLeGjb7u4uXqeF9q/ArcGIS/rest/services`
 1. Clone this repo and install dependencies via `npm install`
 2. Copy `.env.sample` to `.env` and fill in `PROXY_TO` with the path to your Geoservices (ex. `http://maps2.dcgis.dc.gov/dcgis/rest/services/`)
 and any default parameters in `DEFAULT_PARAMS` in `a=b&c=d` format
-3. Run the server via `npm run server`
+3. Run the server via `npm start`
 4. Append the service to your URL and use SODA2 querystring parameters
 
 For example:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Query [Esri Geoservices](http://geoservices.github.io/) using a [SODA2](https://dev.socrata.com/docs/queries/)-style API
 
-This is still a work in progress. Check out the [list of features](https://github.com/timwis/soda-geoservices/issues/1) and 
+This is still a work in progress. Check out the [list of features](https://github.com/timwis/soda-geoservices/issues/1) and
 [tests](test/convert-query.test.js) to get an idea for the functionality.
 
 ## Why?
@@ -46,3 +46,6 @@ http://localhost:8080/DDOT/AlleyConditions/MapServer/0?alley_material=Asphalt
 * [SODA2 Documentation](https://dev.socrata.com/docs/queries/)
 * [Supported functions for ArcGIS Server](http://resources.arcgis.com/en/help/main/10.2/index.html#//015400000686000000) (v10.2)
 * [Validate SQL](https://services.arcgis.com/fLeGjb7u4uXqeF9q/arcgis/rest/services/APPEALS_LIRB/FeatureServer/0/validateSQL)
+
+## License
+[MIT](LICENSE)

--- a/package.json
+++ b/package.json
@@ -1,15 +1,11 @@
 {
   "name": "soda-geoservices",
-  "version": "1.0.0",
   "description": "Query Esri Geoservices using a SODA2-style API",
-  "main": "server.js",
-  "scripts": {
-    "lint": "standard --verbose | snazzy",
-    "test": "mocha test",
-    "server": "node server.js"
+  "version": "1.0.0",
+  "author": "Tim Wisniewski <tim@timwis.com>",
+  "bugs": {
+    "url": "https://github.com/timwis/soda-geoservices/issues"
   },
-  "author": "timwis <tim@timwis.com>",
-  "license": "MIT",
   "dependencies": {
     "checkenv": "^1.0.5",
     "dotenv": "^1.2.0",
@@ -25,5 +21,24 @@
     "should": "^7.1.1",
     "snazzy": "^2.0.1",
     "standard": "^5.4.1"
+  },
+  "homepage": "https://github.com/timwis/soda-geoservices#readme",
+  "keywords": [
+    "esri",
+    "geoservices",
+    "query",
+    "soda",
+    "soda2"
+  ],
+  "license": "MIT",
+  "main": "server.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/timwis/soda-geoservices.git"
+  },
+  "scripts": {
+    "lint": "standard --verbose | snazzy",
+    "start": "node server.js",
+    "test": "mocha test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "soda-geoservices",
   "version": "1.0.0",
   "description": "Query Esri Geoservices using a SODA2-style API",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
-    "lint": "./node_modules/standard/bin/cmd.js --verbose | ./node_modules/snazzy/bin/cmd.js",
-    "test": "./node_modules/mocha/bin/mocha test",
+    "lint": "standard --verbose | snazzy",
+    "test": "mocha test",
     "server": "node server.js"
   },
   "author": "timwis <tim@timwis.com>",

--- a/test/convert-query.test.js
+++ b/test/convert-query.test.js
@@ -1,7 +1,6 @@
 /* global describe, it */
 require('should')
 var convert = require('../convert-query')
-var inspect = require('../helpers/inspect')
 
 describe('select', function () {
   it('all fields', function () {

--- a/test/convert-response.test.js
+++ b/test/convert-response.test.js
@@ -1,4 +1,4 @@
-/* global describe, it, before */
+/* global describe, it */
 require('should')
 var convert = require('../convert-response')
 // var inspect = require('../helpers/inspect')


### PR DESCRIPTION
Hi @timwis!

Cool project! I added a couple things and fixed a couple things, feel free to merge or toss this out if you don't agree as some of the `package.json` fixes are a bit prescriptive.
- I added a `LICENSE` file and linked to it from your `README.md`.
- I fixed two `no-unused-vars` errors in `tests/` that were causing the linter to fail.
- I removed relative links to `./node_modules/` binaries in `scripts` (`npm` will pick these up for you, so you can just write it as `"lint": "standard --verbose | snazzy",` instead of `"lint": "./node_modules/standard/bin/cmd.js --verbose | ./node_modules/snazzy/bin/cmd.js",`.
- I ran [`fixpack`](https://github.com/HenrikJoreteg/fixpack), a handy utility for organizing and linting `package.json` files, and added some missing properties (bugs, homepage, keywords, repository).
- I changed the `server` script to `start`, so you can just run `npm start` instead of `npm run server` now. `start` and `test` are the two standard script commands that `npm` will recognize for free (so you can run `npm start` and `npm test` instead of `npm run ...` -- less typing! yay) `start` is also the default command cloud deployment services like heroku will look for.
- I fixed the `main` property in `package.json` which was pointing to a non-existent `index.js` file.
